### PR TITLE
add /rtp and /spawn

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 archivesBaseName = project.archives_base_name
-version = project.mod_version
+version = "${project.mod_version}-MC${project.minecraft_version}"
 group = project.maven_group
 
 configurations {
@@ -137,4 +137,3 @@ publishing {
 }
 
 compileKotlin.kotlinOptions.jvmTarget = "1.8"
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1G
 	loom_version=0.5-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.4.1-alpha.1
+	mod_version = 1.4.1
 	maven_group = me.gserv
 	archives_base_name = FabriKommander
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1G
 	loom_version=0.5-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.3.0-alpha.2
+	mod_version = 1.4.0
 	maven_group = me.gserv
 	archives_base_name = FabriKommander
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1G
 	loom_version=0.5-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.4.0
+	mod_version = 1.4.1-alpha.1
 	maven_group = me.gserv
 	archives_base_name = FabriKommander
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1G
 	loom_version=0.5-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.4.1
+	mod_version = 1.4.2
 	maven_group = me.gserv
 	archives_base_name = FabriKommander
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1G
 	loom_version=0.5-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.2.1-DEV
+	mod_version = 1.3.0-alpha.2
 	maven_group = me.gserv
 	archives_base_name = FabriKommander
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# Check these on https://modmuss50.me/fabric.html
-	minecraft_version=1.16.4
-	yarn_mappings=1.16.4+build.7
+	minecraft_version=20w49a
+	yarn_mappings=20w49a+build.11
 	loader_version=0.10.8
 
 	#Fabric api
-	fabric_version=0.28.1+1.16
+	fabric_version=0.28.1+1.17
 
 	loom_version=0.5-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.0.1-MC1.16.4
+	mod_version = 1.2.1-DEV
 	maven_group = me.gserv
 	archives_base_name = FabriKommander
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# Check these on https://modmuss50.me/fabric.html
-	minecraft_version=20w49a
-	yarn_mappings=20w49a+build.11
+	minecraft_version=20w51a
+	yarn_mappings=20w51a+build.1
 	loader_version=0.10.8
 
 	#Fabric api
-	fabric_version=0.28.1+1.17
+	fabric_version=0.28.2+1.17
 
 	loom_version=0.5-SNAPSHOT
 

--- a/src/main/kotlin/me/gserv/fabrikommander/Common.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/Common.kt
@@ -2,6 +2,7 @@ package me.gserv.fabrikommander
 
 import me.gserv.fabrikommander.commands.*
 import me.gserv.fabrikommander.data.PlayerDataManager
+import me.gserv.fabrikommander.data.SpawnDataManager
 import me.gserv.fabrikommander.utils.Dispatcher
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback
@@ -13,6 +14,7 @@ object Common : ModInitializer {
 
     override fun onInitialize() {
         PlayerDataManager.setup()
+        SpawnDataManager.setup()
 
         CommandRegistrationCallback.EVENT.register(::registerCommands)
     }
@@ -37,6 +39,8 @@ object Common : ModInitializer {
         // Teleport commands
         BackCommand(dispatcher).register()
         RtpCommand(dispatcher).register()
+        SpawnCommand(dispatcher).register()
+        SetSpawnCommand(dispatcher).register()
 
         // Misc commands
         PingCommand(dispatcher).register()

--- a/src/main/kotlin/me/gserv/fabrikommander/Common.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/Common.kt
@@ -36,6 +36,7 @@ object Common : ModInitializer {
         
         // Teleport commands
         BackCommand(dispatcher).register()
+        RtpCommand(dispatcher).register()
 
         // Misc commands
         PingCommand(dispatcher).register()

--- a/src/main/kotlin/me/gserv/fabrikommander/Common.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/Common.kt
@@ -39,5 +39,6 @@ object Common : ModInitializer {
 
         // Misc commands
         PingCommand(dispatcher).register()
+        DieCommand(dispatcher).register()
     }
 }

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/BackCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/BackCommand.kt
@@ -14,13 +14,13 @@ import me.gserv.fabrikommander.utils.identifierToWorldName
 import me.gserv.fabrikommander.utils.plus
 import me.gserv.fabrikommander.utils.red
 import me.gserv.fabrikommander.utils.yellow
+import net.minecraft.util.Util
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.server.command.CommandManager.literal
 import net.minecraft.util.registry.Registry
 import net.minecraft.util.registry.RegistryKey
 
 class BackCommand(val dispatcher: Dispatcher) {
-    val backHeader = gray("[") + yellow("Back") + gray("] ") + reset("")
     companion object Utils {
         // Mixin had a problem with @Shadow-ing sendMessage so I'm doing it here
         // Also, apparently functions inside companion objects are automatically static, neat!
@@ -41,6 +41,7 @@ class BackCommand(val dispatcher: Dispatcher) {
 
     fun backCommand(context: Context): Int {
         val player = context.source.player
+        val backHeader = gray("[") + yellow("Back") + gray("] ") + reset("")
         if (PlayerDataManager.getBackPos(player.uuid) == null) {
             context.source.sendError(
                 backHeader + red("No last position defined - you will have to teleport.")
@@ -74,7 +75,8 @@ class BackCommand(val dispatcher: Dispatcher) {
         )
         player.teleport(world, pos.x, pos.y, pos.z, pos.yaw, pos.pitch)
         context.source.sendFeedback(
-            backHeader + gold("Successfully teleported back!"),
+            backHeader + gold("Successfully teleported back to ") +
+            aqua("[${pos.x.toInt()}, ${pos.y.toInt()}, ${pos.z.toInt()}]"),
             false
         )
         return 1

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/DieCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/DieCommand.kt
@@ -1,0 +1,26 @@
+package me.gserv.fabrikommander.commands
+
+import me.gserv.fabrikommander.utils.Context
+import me.gserv.fabrikommander.utils.Dispatcher
+import me.gserv.fabrikommander.utils.red
+import net.minecraft.server.command.CommandManager
+import net.minecraft.text.LiteralText
+
+class DieCommand(val dispatcher: Dispatcher) {
+    fun register() {
+        dispatcher.register(
+            CommandManager.literal("die")
+                .executes { dieCommand(it) }
+        )
+    }
+
+    fun dieCommand(context: Context): Int {
+        context.source.player.kill()
+        context.source.sendFeedback(
+            red("You died"),
+            false
+        )
+
+        return 1
+    }
+}

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
@@ -39,7 +39,7 @@ class RtpCommand(val dispatcher: Dispatcher) {
             return generateCoordinates(world)
         }
 
-        return listOf(x, y, z)
+        return listOf(x, y + 1, z)
     }
 
     private fun getHighestBlock(world: ServerWorld?, x: Int, z: Int): Int {

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
@@ -55,9 +55,8 @@ class RtpCommand(val dispatcher: Dispatcher) {
 
     fun rtpCommand(context: Context): Int {
         val player = context.source.player
-        val overworld = Identifier("minecraft:overworld")
-        val world = player.server.getWorld(RegistryKey.of(Registry.DIMENSION, overworld))
-        val coordinates = generateCoordinates(world)
+        val overworld = player.server.getWorld(RegistryKey.of(Registry.DIMENSION, Identifier("minecraft:overworld")))
+        val coordinates = generateCoordinates(overworld)
 
         PlayerDataManager.setBackPos(
             player.uuid,
@@ -72,7 +71,7 @@ class RtpCommand(val dispatcher: Dispatcher) {
         )
 
         player.teleport(
-            world,
+            overworld,
             coordinates[0].toDouble(),
             coordinates[1].toDouble(),
             coordinates[2].toDouble(),

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
@@ -1,0 +1,94 @@
+package me.gserv.fabrikommander.commands
+
+import me.gserv.fabrikommander.data.PlayerDataManager
+import me.gserv.fabrikommander.data.spec.Pos
+import me.gserv.fabrikommander.utils.Context
+import me.gserv.fabrikommander.utils.Dispatcher
+import me.gserv.fabrikommander.utils.gold
+import me.gserv.fabrikommander.utils.gray
+import me.gserv.fabrikommander.utils.yellow
+import me.gserv.fabrikommander.utils.plus
+import me.gserv.fabrikommander.utils.aqua
+import net.minecraft.server.command.CommandManager
+import net.minecraft.util.Identifier
+import net.minecraft.server.world.ServerWorld
+import net.minecraft.util.registry.Registry
+import net.minecraft.util.registry.RegistryKey
+import net.minecraft.util.math.BlockPos
+
+class RtpCommand(val dispatcher: Dispatcher) {
+    private val rtpRange = -5000..5000
+
+    fun register() {
+        dispatcher.register(
+            CommandManager.literal("rtp")
+                .executes { rtpCommand(it) }
+        )
+        dispatcher.register(
+            CommandManager.literal("wild")
+                .executes { rtpCommand(it) }
+        )
+    }
+    
+    private fun generateCoordinates(world: ServerWorld?): List<Int> {
+        val x = rtpRange.random()
+        val z = rtpRange.random()
+        val y = getHighestBlock(world, x, z)
+
+        if (world?.isWater(BlockPos(x, y, z)) == true) {
+            return generateCoordinates(world)
+        }
+
+        return listOf(x, y, z)
+    }
+
+    private fun getHighestBlock(world: ServerWorld?, x: Int, z: Int): Int {
+        val heightLimit = world!!.heightLimit
+
+        for (height in heightLimit downTo 0)
+            if (!world.isAir(BlockPos(x, height, z))) {
+                return height
+            }
+
+        return 0
+    }
+
+    fun rtpCommand(context: Context): Int {
+        val player = context.source.player
+        val overworld = Identifier("minecraft:overworld")
+        val world = player.server.getWorld(RegistryKey.of(Registry.DIMENSION, overworld))
+        val coordinates = generateCoordinates(world)
+
+        PlayerDataManager.setBackPos(
+            player.uuid,
+            Pos(
+                x = player.x,
+                y = player.y,
+                z = player.z,
+                world = player.world.registryKey.value,
+                yaw = player.yaw,
+                pitch = player.pitch
+            )
+        )
+
+        player.teleport(
+            world,
+            coordinates[0].toDouble(),
+            coordinates[1].toDouble(),
+            coordinates[2].toDouble(),
+            player.yaw,
+            player.pitch
+        )
+        context.source.sendFeedback(
+            gray("[") +
+            yellow("RTP") +
+            gray("] ") +
+            gold("Randomly teleported to ") +
+            aqua("[${player.x.toInt()}, ${player.y.toInt()}, ${player.z.toInt()}]"),
+            true
+        )
+        
+
+        return 1
+    }
+}

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/SetSpawnCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/SetSpawnCommand.kt
@@ -1,0 +1,44 @@
+package me.gserv.fabrikommander.commands
+
+import me.gserv.fabrikommander.data.SpawnDataManager
+import me.gserv.fabrikommander.data.spec.Spawn
+import me.gserv.fabrikommander.data.spec.Pos
+import me.gserv.fabrikommander.utils.*
+import net.minecraft.server.command.CommandManager
+
+class SetSpawnCommand(val dispatcher: Dispatcher) {
+    fun register() {
+        dispatcher.register(
+            CommandManager.literal("setspawn")
+                .executes { setSpawnCommand(it) }
+                .requires { it.hasPermissionLevel(2) }
+        )
+    }
+
+    fun setSpawnCommand(context: Context): Int {
+        val player = context.source.player
+
+        val spawn = Spawn(
+            pos = Pos(
+                x = player.x,
+                y = player.y,
+                z = player.z,
+                yaw = player.yaw,
+                pitch = player.pitch,
+                world = player.world.registryKey.value
+            ),
+        )
+
+        SpawnDataManager.setSpawn(spawn)
+
+        context.source.sendFeedback(
+            green("Spawn created at ") +
+                    aqua("[${player.x.toInt()}, ${player.y.toInt()}, ${player.z.toInt()}]") +
+                    green(" in the ") +
+                    aqua(identifierToWorldName(player.world.registryKey.value)),
+            true
+        )
+
+        return 1
+    }
+}

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/SpawnCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/SpawnCommand.kt
@@ -1,0 +1,67 @@
+package me.gserv.fabrikommander.commands
+
+import com.mojang.brigadier.arguments.StringArgumentType
+import me.gserv.fabrikommander.data.SpawnDataManager
+import me.gserv.fabrikommander.data.PlayerDataManager
+import me.gserv.fabrikommander.data.spec.Pos
+import me.gserv.fabrikommander.utils.Context
+import me.gserv.fabrikommander.utils.Dispatcher
+import me.gserv.fabrikommander.utils.aqua
+import me.gserv.fabrikommander.utils.green
+import me.gserv.fabrikommander.utils.identifierToWorldName
+import me.gserv.fabrikommander.utils.plus
+import me.gserv.fabrikommander.utils.red
+import me.gserv.fabrikommander.utils.yellow
+import net.minecraft.server.command.CommandManager
+import net.minecraft.util.registry.Registry
+import net.minecraft.util.registry.RegistryKey
+
+class SpawnCommand(val dispatcher: Dispatcher) {
+    fun register() {
+        dispatcher.register(
+            CommandManager.literal("spawn")
+                .executes { spawnCommand(it) }
+        )
+    }
+
+    fun spawnCommand(context: Context): Int {
+        val player = context.source.player
+        val spawn = SpawnDataManager.getSpawn()
+
+        val world = player.server.getWorld(RegistryKey.of(Registry.DIMENSION, spawn.pos.world))
+
+        if (world == null) {
+            context.source.sendFeedback(
+                red("Warp ") +
+                        aqua("spawn") +
+                        red(" is in a world ") +
+                        yellow("(") +
+                        aqua(identifierToWorldName(spawn.pos.world)) +
+                        yellow(") ") +
+                        red("that no longer exists."),
+                false
+            )
+        } else {
+            PlayerDataManager.setBackPos(
+                player.uuid,
+                Pos(
+                    x = player.x,
+                    y = player.y,
+                    z = player.z,
+                    world = player.world.registryKey.value,
+                    yaw = player.yaw,
+                    pitch = player.pitch
+                )
+            )
+
+            player.teleport(world, spawn.pos.x, spawn.pos.y, spawn.pos.z, spawn.pos.yaw, spawn.pos.pitch)
+
+            context.source.sendFeedback(
+                green("Teleported to spawn!"),
+                true
+            )
+        }
+
+        return 1
+    }
+}

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpAcceptCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpAcceptCommand.kt
@@ -32,7 +32,7 @@ class TpAcceptCommand(val dispatcher: Dispatcher) {
         if (request == null) {
             context.source.sendError(
                 messageHeader + 
-                red("No active teleport request from ") + aqua(source.displayName.asString())
+                red("No active teleport request from ") + aqua(source.entityName)
             )
             return 0
         }

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpAcceptCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpAcceptCommand.kt
@@ -16,8 +16,6 @@ import net.minecraft.server.command.CommandManager.literal
 
 // I'm not sure how I should capitalise this
 class TpAcceptCommand(val dispatcher: Dispatcher) {
-    val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
-
     fun register() {
         dispatcher.register(
             literal("tpaccept").then(
@@ -29,6 +27,7 @@ class TpAcceptCommand(val dispatcher: Dispatcher) {
     fun tpAcceptCommand(context: Context): Int {
         val source = EntityArgumentType.getPlayer(context, "source")
         val request = TeleportRequest.ACTIVE_REQUESTS[source.uuidAsString + context.source.player.uuidAsString]
+        val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
         if (request == null) {
             context.source.sendError(
                 messageHeader + 

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpCancelCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpCancelCommand.kt
@@ -30,7 +30,7 @@ class TpCancelCommand(val dispatcher: Dispatcher) {
         if (TeleportRequest.ACTIVE_REQUESTS[context.source.player.uuidAsString + target.uuidAsString] == null) {
             context.source.sendError(
                 messageHeader + 
-                red("No active teleport request to ") + aqua(target.displayName.asString())
+                red("No active teleport request to ") + aqua(target.entityName)
             )
             return 0
         }
@@ -39,7 +39,7 @@ class TpCancelCommand(val dispatcher: Dispatcher) {
         context.source.sendFeedback(
             messageHeader +     
             darkPurple("Teleport request to ") + 
-            aqua(target.displayName.asString()) + 
+            aqua(target.entityName) + 
             darkPurple(" was cancelled."), 
             true
         )

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpCancelCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpCancelCommand.kt
@@ -15,8 +15,6 @@ import net.minecraft.server.command.CommandManager.argument
 import net.minecraft.server.command.CommandManager.literal
 
 class TpCancelCommand(val dispatcher: Dispatcher) {
-    val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
-
     fun register() {
         dispatcher.register(
             literal("tpcancel").then(
@@ -27,6 +25,7 @@ class TpCancelCommand(val dispatcher: Dispatcher) {
 
     fun tpCancelCommand(context: Context): Int {
         val target = EntityArgumentType.getPlayer(context, "target")
+        val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
         if (TeleportRequest.ACTIVE_REQUESTS[context.source.player.uuidAsString + target.uuidAsString] == null) {
             context.source.sendError(
                 messageHeader + 

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpDenyCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpDenyCommand.kt
@@ -15,8 +15,6 @@ import net.minecraft.server.command.CommandManager.argument
 import net.minecraft.server.command.CommandManager.literal
 
 class TpDenyCommand(val dispatcher: Dispatcher) {
-    val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
-
     fun register() {
         dispatcher.register(
             literal("tpdeny").then(
@@ -27,6 +25,7 @@ class TpDenyCommand(val dispatcher: Dispatcher) {
 
     fun tpDenyCommand(context: Context): Int {
         val source = EntityArgumentType.getPlayer(context, "source")
+        val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
         if (TeleportRequest.ACTIVE_REQUESTS[source.uuidAsString + context.source.player.uuidAsString] == null) {
             context.source.sendError(
                 messageHeader + red("No active teleport request from ") + aqua(source.entityName)

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpDenyCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpDenyCommand.kt
@@ -29,14 +29,14 @@ class TpDenyCommand(val dispatcher: Dispatcher) {
         val source = EntityArgumentType.getPlayer(context, "source")
         if (TeleportRequest.ACTIVE_REQUESTS[source.uuidAsString + context.source.player.uuidAsString] == null) {
             context.source.sendError(
-                messageHeader + red("No active teleport request from ") + aqua(source.displayName.asString())
+                messageHeader + red("No active teleport request from ") + aqua(source.entityName)
             )
             return 0
         }
         TeleportRequest.ACTIVE_REQUESTS[source.uuidAsString + context.source.player.uuidAsString]!!.notifySourceOfDeny()
         TeleportRequest.ACTIVE_REQUESTS.remove(source.uuidAsString + context.source.player.uuidAsString)
         context.source.sendFeedback(
-            messageHeader + darkPurple("Teleport request from ") + aqua(source.displayName.asString()) + darkPurple(" was denied"),
+            messageHeader + darkPurple("Teleport request from ") + aqua(source.entityName) + darkPurple(" was denied"),
             true
         )
         return 1

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpaCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpaCommand.kt
@@ -10,13 +10,16 @@ import me.gserv.fabrikommander.utils.red
 import me.gserv.fabrikommander.utils.gray
 import me.gserv.fabrikommander.utils.yellow
 import me.gserv.fabrikommander.utils.reset
+import me.gserv.fabrikommander.utils.hover
+import me.gserv.fabrikommander.utils.click
+import net.minecraft.util.Util
+import net.minecraft.text.ClickEvent
+import net.minecraft.text.HoverEvent
 import net.minecraft.command.argument.EntityArgumentType
 import net.minecraft.server.command.CommandManager.argument
 import net.minecraft.server.command.CommandManager.literal
 
 class TpaCommand(val dispatcher: Dispatcher) {
-    val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
-
     fun register() {
         dispatcher.register(
             literal("tpa").then(
@@ -29,10 +32,24 @@ class TpaCommand(val dispatcher: Dispatcher) {
         val target = EntityArgumentType.getPlayer(context, "target")
         val source = context.source.player
         val request = TeleportRequest(source = source, target = target, inverted = false)
+        val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
         request.notifyTargetOfRequest()
         context.source.sendFeedback(
-            messageHeader + 
-            darkPurple("Teleport request sent to ") + aqua(target.entityName),
+            messageHeader +
+            aqua("Teleport request sent to ") + target.displayName + 
+            reset(" ") + hover(
+                click(
+                    red("[X]"),
+                    ClickEvent(
+                        ClickEvent.Action.RUN_COMMAND,
+                        "/tpcancel " + target.entityName // There can be multiple active requests
+                    )
+                ),
+                HoverEvent(
+                    HoverEvent.Action.SHOW_TEXT,
+                    red("Click here to cancel the request.")
+                )
+            ) + reset(""),
             true
         )
         return 1

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpaCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpaCommand.kt
@@ -32,7 +32,7 @@ class TpaCommand(val dispatcher: Dispatcher) {
         request.notifyTargetOfRequest()
         context.source.sendFeedback(
             messageHeader + 
-            darkPurple("Teleport request sent to ") + aqua(target.displayName.asString()),
+            darkPurple("Teleport request sent to ") + aqua(target.entityName),
             true
         )
         return 1

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpaHereCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpaHereCommand.kt
@@ -10,13 +10,16 @@ import me.gserv.fabrikommander.utils.red
 import me.gserv.fabrikommander.utils.gray
 import me.gserv.fabrikommander.utils.yellow
 import me.gserv.fabrikommander.utils.reset
+import me.gserv.fabrikommander.utils.hover
+import me.gserv.fabrikommander.utils.click
+import net.minecraft.util.Util
+import net.minecraft.text.ClickEvent
+import net.minecraft.text.HoverEvent
 import net.minecraft.command.argument.EntityArgumentType
 import net.minecraft.server.command.CommandManager.argument
 import net.minecraft.server.command.CommandManager.literal
 
 class TpaHereCommand(val dispatcher: Dispatcher) {
-    val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
-
     fun register() {
         dispatcher.register(
             literal("tpahere").then(
@@ -29,11 +32,24 @@ class TpaHereCommand(val dispatcher: Dispatcher) {
         val target = EntityArgumentType.getPlayer(context, "target")
         val source = context.source.player
         val request = TeleportRequest(source = source, target = target, inverted = true)
+        val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
         request.notifyTargetOfRequest()
         context.source.sendFeedback(
-            messageHeader + 
-            darkPurple("Teleport request sent to ") + aqua(target.entityName) +
-            reset(""),
+            messageHeader +
+            aqua("Teleport request sent to ") + target.displayName + 
+            reset(" ") + hover(
+                click(
+                    red("[X]"),
+                    ClickEvent(
+                        ClickEvent.Action.RUN_COMMAND,
+                        "/tpcancel " + target.entityName // There can be multiple active requests
+                    )
+                ),
+                HoverEvent(
+                    HoverEvent.Action.SHOW_TEXT,
+                    red("Click here to cancel the request.")
+                )
+            ) + reset(""),
             true
         )
         return 1

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpaHereCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpaHereCommand.kt
@@ -32,7 +32,7 @@ class TpaHereCommand(val dispatcher: Dispatcher) {
         request.notifyTargetOfRequest()
         context.source.sendFeedback(
             messageHeader + 
-            darkPurple("Teleport request sent to ") + aqua(target.displayName.asString()),
+            darkPurple("Teleport request sent to ") + aqua(target.entityName),
             true
         )
         return 1

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/TpaHereCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/TpaHereCommand.kt
@@ -32,7 +32,8 @@ class TpaHereCommand(val dispatcher: Dispatcher) {
         request.notifyTargetOfRequest()
         context.source.sendFeedback(
             messageHeader + 
-            darkPurple("Teleport request sent to ") + aqua(target.entityName),
+            darkPurple("Teleport request sent to ") + aqua(target.entityName) +
+            reset(""),
             true
         )
         return 1

--- a/src/main/kotlin/me/gserv/fabrikommander/data/SpawnDataManager.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/data/SpawnDataManager.kt
@@ -1,0 +1,80 @@
+package me.gserv.fabrikommander.data
+
+import com.charleskorn.kaml.Yaml
+import me.gserv.fabrikommander.data.spec.Player
+import me.gserv.fabrikommander.data.spec.Pos
+import me.gserv.fabrikommander.data.spec.Spawn
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents
+import net.minecraft.util.Identifier
+import net.minecraft.util.WorldSavePath
+import org.apache.logging.log4j.LogManager
+import java.nio.file.Path
+import kotlin.NoSuchElementException
+
+object SpawnDataManager {
+    private val logger = LogManager.getLogger(this::class.java)
+
+    private lateinit var dataDir: Path
+
+    fun setup() {
+        ServerLifecycleEvents.SERVER_STARTING.register {
+            dataDir = it.getSavePath(WorldSavePath.ROOT).resolve("FabriKommander")
+
+            dataDir.toFile().mkdir()
+
+            logger.info("Data directory: $dataDir")
+        }
+    }
+
+    fun loadData(): Spawn {
+        val spawnFile = dataDir.resolve("spawn.yaml").toFile()
+
+        if (!spawnFile.exists()) {
+            spawnFile.createNewFile()
+
+            val data = Spawn(pos = Pos(
+                0.0,
+                75.0,
+                0.0,
+
+                0F,
+                0F,
+
+                Identifier("minecraft:overworld")
+            ))
+
+            spawnFile.writeText(
+                Yaml.default.encodeToString(Spawn.serializer(), data)
+            )
+
+            return data
+        }
+
+        val string = spawnFile.readText()
+        return Yaml.default.decodeFromString(Spawn.serializer(), string)
+    }
+
+    fun setSpawn(spawn: Spawn): Boolean? {
+        saveData(spawn)
+
+        return true
+    }
+
+
+    fun getSpawn(): Spawn {
+        return loadData()
+    }
+
+    fun saveData(spawn: Spawn) {
+        val spawnFile = dataDir.resolve("spawn.yaml").toFile()
+            ?: throw NoSuchElementException("No spawn config found")
+
+        if (!spawnFile.exists()) {
+            spawnFile.createNewFile()
+        }
+
+        spawnFile.writeText(
+            Yaml.default.encodeToString(Spawn.serializer(), spawn)
+        )
+    }
+}

--- a/src/main/kotlin/me/gserv/fabrikommander/data/TeleportRequest.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/data/TeleportRequest.kt
@@ -8,6 +8,7 @@ import me.gserv.fabrikommander.utils.plus
 import me.gserv.fabrikommander.utils.red
 import me.gserv.fabrikommander.utils.reset
 import me.gserv.fabrikommander.utils.yellow
+import me.gserv.fabrikommander.data.spec.Pos
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.ClickEvent
 import net.minecraft.text.HoverEvent
@@ -81,9 +82,9 @@ class TeleportRequest(
                     true -> "you teleport to them"
                     false -> "to teleport to you"
                 }
-            ) + reset(". [") + click(
+            ) + reset(". ") + click(
                 hover(
-                    aqua("Accept"),
+                    green("[✓]"),
                     HoverEvent(
                         HoverEvent.Action.SHOW_TEXT,
                         green("Click here to accept the request.")
@@ -93,9 +94,9 @@ class TeleportRequest(
                     ClickEvent.Action.RUN_COMMAND,
                     "/tpaccept " + source.entityName // There can be multiple active requests
                 )
-            ) + reset(" / ") + hover(
+            ) + reset(" ") + hover(
                 click(
-                    aqua("Deny"),
+                    red("[X]"),
                     ClickEvent(
                         ClickEvent.Action.RUN_COMMAND,
                         "/tpdeny " + source.entityName // There can be multiple active requests
@@ -105,7 +106,7 @@ class TeleportRequest(
                     HoverEvent.Action.SHOW_TEXT,
                     red("Click here to deny the request.")
                 )
-            ) + reset("]")
+            ) + reset("")
 
         target.sendSystemMessage(message, Util.NIL_UUID)
     }

--- a/src/main/kotlin/me/gserv/fabrikommander/data/TeleportRequest.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/data/TeleportRequest.kt
@@ -9,7 +9,6 @@ import me.gserv.fabrikommander.utils.plus
 import me.gserv.fabrikommander.utils.red
 import me.gserv.fabrikommander.utils.reset
 import me.gserv.fabrikommander.utils.yellow
-import me.gserv.fabrikommander.data.spec.Pos
 import me.gserv.fabrikommander.utils.darkPurple
 import me.gserv.fabrikommander.utils.gray
 import net.minecraft.server.network.ServerPlayerEntity
@@ -23,9 +22,8 @@ class TeleportRequest(
     val target: ServerPlayerEntity,
     val inverted: Boolean
 ) {
-    /*
     val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
-
+    /*
     val tpaMessage = aqua(source.entityName) + darkPurple(" has requested to teleport to you") + reset(" ")
     val tpaMessageInverted = aqua(source.entityName) + darkPurple(" has requested you teleport to them") + reset(" ")
     
@@ -114,19 +112,19 @@ class TeleportRequest(
     }
 
     fun notifySourceOfAccept() {
-        val message = aqua(target.displayName.asString()) + darkPurple(" has accepted your teleport request")
+        val message = aqua(target.entityName) + darkPurple(" has accepted your teleport request")
         source.sendSystemMessage(message, Util.NIL_UUID)
     }
 
     fun notifySourceOfDeny() {
-        val message = messageHeader + aqua(target.displayName.asString()) + darkPurple(" has denied your teleport request")
+        val message = messageHeader + aqua(target.entityName) + darkPurple(" has denied your teleport request")
         source.sendSystemMessage(message, Util.NIL_UUID)
     }
 
     fun notifyTargetOfRequest() {
         // Message will be configurable later
         val message =
-            reset("") + source.displayName as MutableText + yellow( // reset("") used to make the vanilla click event for player names not apply to the whole message
+            messageHeader + source.displayName as MutableText + yellow( // reset("") used to make the vanilla click event for player names not apply to the whole message
                 " has requested " + when (inverted) {
                     true -> "you teleport to them"
                     false -> "to teleport to you"
@@ -161,7 +159,7 @@ class TeleportRequest(
     }
 
     fun notifyTargetOfCancel() {
-        val message = messageHeader + aqua(source.displayName.asString()) + darkPurple(" has cancelled their teleport request")
+        val message = messageHeader + aqua(source.entityName) + darkPurple(" has cancelled their teleport request")
         target.sendSystemMessage(message, Util.NIL_UUID)
     }
 }

--- a/src/main/kotlin/me/gserv/fabrikommander/data/TeleportRequest.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/data/TeleportRequest.kt
@@ -22,7 +22,6 @@ class TeleportRequest(
     val target: ServerPlayerEntity,
     val inverted: Boolean
 ) {
-    val messageHeader = gray("[") + yellow("TPA") + gray("] ") + reset("")
     /*
     val tpaMessage = aqua(source.entityName) + darkPurple(" has requested to teleport to you") + reset(" ")
     val tpaMessageInverted = aqua(source.entityName) + darkPurple(" has requested you teleport to them") + reset(" ")
@@ -117,14 +116,17 @@ class TeleportRequest(
     }
 
     fun notifySourceOfDeny() {
-        val message = messageHeader + aqua(target.entityName) + darkPurple(" has denied your teleport request")
+        val message = 
+        gray("[") + yellow("TPA") + gray("] ") + reset("") + 
+        aqua(target.entityName) + darkPurple(" has denied your teleport request")
         source.sendSystemMessage(message, Util.NIL_UUID)
     }
 
     fun notifyTargetOfRequest() {
         // Message will be configurable later
         val message =
-            messageHeader + source.displayName as MutableText + yellow( // reset("") used to make the vanilla click event for player names not apply to the whole message
+            gray("[") + yellow("TPA") + gray("] ") + reset("") + 
+            source.displayName as MutableText + yellow( // reset("") used to make the vanilla click event for player names not apply to the whole message
                 " has requested " + when (inverted) {
                     true -> "you teleport to them"
                     false -> "to teleport to you"
@@ -159,7 +161,9 @@ class TeleportRequest(
     }
 
     fun notifyTargetOfCancel() {
-        val message = messageHeader + aqua(source.entityName) + darkPurple(" has cancelled their teleport request")
+        val message =
+            gray("[") + yellow("TPA") + gray("] ") + reset("") + 
+            aqua(source.entityName) + darkPurple(" has cancelled their teleport request")
         target.sendSystemMessage(message, Util.NIL_UUID)
     }
 }

--- a/src/main/kotlin/me/gserv/fabrikommander/data/spec/Spawn.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/data/spec/Spawn.kt
@@ -1,0 +1,8 @@
+package me.gserv.fabrikommander.data.spec
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Spawn(
+    val pos: Pos
+)

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -41,7 +41,7 @@
     "fabricloader": ">=0.8.7",
     "fabric": "*",
     "fabric-language-kotlin": "*",
-    "minecraft": "1.16.x"
+    "minecraft": "1.17.x"
   },
 
   "suggests": {


### PR DESCRIPTION
/rtp teleports the player to a random position in a 5000 block radius of the center of the world
 - Currently, this is hard coded, but I will add /rtprange and /rtpcenter soon:tm:
 - /rtp will update the player's back position
 - Always teleports the player in the overworld

/spawn defaults to `0 75 0` in the overworld, but can be changed with /setspawn or by editing the config file `spawn.yaml`
 - /setspawn is a restricted command and sets the spawn position to the location that the user is standing